### PR TITLE
Add update to apk upgrade line, ensure index present when patching

### DIFF
--- a/jumper/base/Dockerfile
+++ b/jumper/base/Dockerfile
@@ -6,7 +6,7 @@ RUN /usr/bin/ssh-keygen -A
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/jumper/sbin/jumperd"]
 RUN echo "Patched Thu Jan  1 00:00:00 UTC 1970"
-RUN apk upgrade
+RUN apk update && apk upgrade
 
 COPY spool/* /root/tmp/
 


### PR DESCRIPTION
Fixes `package mentioned in index not found`

```
Step 9/25 : RUN apk upgrade
 ---> Running in 24e93830bc2f
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.6.8-r1 -> 2.6.8-r2)
ERROR: apk-tools-2.6.8-r2: package mentioned in index not found (try 'apk update')
Continuing the upgrade transaction with new apk-tools:
(1/3) Upgrading musl (1.1.15-r5 -> 1.1.15-r6)
ERROR: musl-1.1.15-r6: package mentioned in index not found (try 'apk update')
(2/3) Upgrading apk-tools (2.6.8-r1 -> 2.6.8-r2)
ERROR: apk-tools-2.6.8-r2: package mentioned in index not found (try 'apk update')
(3/3) Upgrading musl-utils (1.1.15-r5 -> 1.1.15-r6)
ERROR: musl-utils-1.1.15-r6: package mentioned in index not found (try 'apk update')
3 errors; 8 MiB in 15 packages
Removing intermediate container 24e93830bc2f
The command '/bin/sh -c apk upgrade' returned a non-zero code: 3
```